### PR TITLE
Added Docker configuration + HTTPS

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:carbon
+
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+
+RUN npm install
+
+COPY . .
+
+EXPOSE 3000
+
+CMD ["npm", "start"]

--- a/bin/www
+++ b/bin/www
@@ -4,30 +4,44 @@
  * Module dependencies.
  */
 
+const config = require('../config')
+
 var app = require('../app');
 var debug = require('debug')('nodejs:server');
 var http = require('http');
+var https = require('https');
 
 /**
  * Get port from environment and store in Express.
  */
 
-var port = normalizePort(process.env.PORT || '3000');
-app.set('port', port);
+var port = normalizePort(config.port || '3000');
+// app.set('port', port);
 
 /**
  * Create HTTP server.
  */
 
-var server = http.createServer(app);
+var fs = require('fs');
+var privateKey  = fs.readFileSync(config.key, 'utf8');
+var certificate = fs.readFileSync(config.cert, 'utf8');
+
+var credentials = {key: privateKey, cert: certificate};
+var httpServer = http.createServer(app);
+var httpsServer = https.createServer(credentials, app);
 
 /**
  * Listen on provided port, on all network interfaces.
  */
 
-server.listen(port);
-server.on('error', onError);
-server.on('listening', onListening);
+httpServer.listen(config.http_port);
+httpsServer.listen(config.https_port);
+console.log("Server listening on port: ", config.http_port);
+console.log("Server listening on port: ", config.https_port);
+httpServer.on('error', onError);
+httpsServer.on('error', onError);
+httpServer.on('listening', onListening);
+httpsServer.on('listening', onListening);
 
 /**
  * Normalize a port into a number, string, or false.
@@ -82,9 +96,15 @@ function onError(error) {
  */
 
 function onListening() {
-  var addr = server.address();
+  var addr = httpServer.address();
   var bind = typeof addr === 'string'
     ? 'pipe ' + addr
     : 'port ' + addr.port;
-  debug('Listening on ' + bind);
+  console.log('HTTP Listening on ' + bind);
+
+  var addr = httpsServer.address();
+    var bind = typeof addr === 'string'
+      ? 'pipe ' + addr
+      : 'port ' + addr.port;
+    console.log('HTTPS Listening on ' + bind);
 }

--- a/config.json
+++ b/config.json
@@ -1,0 +1,6 @@
+{
+  "http_port": 3000,
+  "https_port": 3210,
+  "key": "privkey.pem",
+  "cert": "cert.pem"
+}

--- a/database.json
+++ b/database.json
@@ -2,18 +2,19 @@
   "defaultEnv": "local",
   "local": {
     "driver": "mysql",
-    "user": "<username>",
-    "password": "<password>",
-    "host": "localhost",
+    "user": "root",
+    "password": "root",
+    "host": "192.168.2.104",
     "database": "migrations",
     "multipleStatements": true
   },
-  "live": {
+  "production": {
     "driver": "mysql",
-    "user": "<username>",
-    "password": "<password>",
-    "host": "<live db host>",
+    "user": "root",
+    "password": "root",
+    "host": "192.168.2.104",
     "database": "migrations",
+    "port": 3307,
     "multipleStatements": true
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '2'
+
+services:
+  maria_db:
+    container_name: poe-db
+    image: mariadb
+    restart: always
+    environment:
+      MYSQL_USER: strongbox
+      MYSQL_PASSWORD: strongbox
+      MYSQL_DATABASE: migrations
+      MYSQL_ROOT_PASSWORD: root
+    ports:
+      - 3307:3306
+    networks:
+      - poe
+
+  strongbox:
+    container_name: poe-strongbox
+    build: .
+    networks: poe
+    environment:
+      NODE_ENV: production
+    restart: always
+    ports:
+      - 3000:3000
+      - 3210:3210
+    networks:
+      - poe
+
+
+networks:
+  poe:
+    driver: bridge

--- a/modules/Db/index.js
+++ b/modules/Db/index.js
@@ -9,6 +9,7 @@ const connection = {
     host: database.host,
     user: database.user,
     password: database.password,
+    port: database.port,
     multipleStatements: true
   }
 };


### PR DESCRIPTION
I've added a simple Docker configuration for easier setup (or for those who prefer running stuff in docker) and somewhat functional HTTPS (need this for my own reverse proxy setups as port 80 is blocked in my firewall).

`bin/www` is still somewhat hacked and it still requires you to run `db-migrate up` from outside the container, though. Rest should be functional enough.

Happy to fix any remaining issues with this :) 